### PR TITLE
Los gifs mostrados en la busqueda ahora son persistentes

### DIFF
--- a/src/app/gifs/services/gifs.service.ts
+++ b/src/app/gifs/services/gifs.service.ts
@@ -28,7 +28,10 @@ export class GifsService {
     // segunda forma
     // le decimos que el historial es igual al resultado pero si esta vacio o nul regresame []
     // igual tenemos que usar el signo !
-    this._historial = JSON.parse( localStorage.getItem('historial')! ) || [];
+    this._historial = JSON.parse( localStorage.getItem( 'historial' )! ) || [];
+
+    // mostrar los ultimos resultados de busqueda
+    this.resultados = JSON.parse( localStorage.getItem( 'resultados' )! ) || [];
   } 
 
   buscarGif( query: string = '' ) {
@@ -48,6 +51,8 @@ export class GifsService {
               .subscribe( ( resp ) => {
                 console.log( resp.data );
                 this.resultados = resp.data;
+                // para mostrar los ultimos gifs mostrado lo tengo que tomar cuando obtengo la respuesta
+                localStorage.setItem( 'resultados', JSON.stringify( this.resultados ) );
               });
   }
 }


### PR DESCRIPTION
Se hacen persistentes los gifs del resultado de la busqueda utilizando el local storage